### PR TITLE
feat(config): add confirmDelete setting to skip delete confirmation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Skip Delete Confirmation**: New `confirmDelete` setting to bypass the confirmation dialog when deleting comments (default: enabled)
+
 ## [1.0.0] - 2025-08-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
           "type": "boolean",
           "default": true,
           "description": "Hide comment highlights when the original text no longer matches the current file content"
+        },
+        "localComments.confirmDelete": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a confirmation dialog before deleting comments. Set to false for immediate deletion."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -966,30 +966,35 @@ async function deleteCommentFromTree(item: CommentTreeItem) {
 }
 
 async function deleteCommentById(commentId: string, fileName: string) {
-    const result = await vscode.window.showWarningMessage(
-        'Are you sure you want to delete this comment?',
-        'Delete', 'Cancel'
-    );
-    
-    if (result === 'Delete') {
-        const fileComments = commentData[fileName];
-        if (fileComments) {
-            const index = fileComments.findIndex(c => c.id === commentId);
-            if (index !== -1) {
-                fileComments.splice(index, 1);
-                if (fileComments.length === 0) {
-                    delete commentData[fileName];
-                }
-                
-                updateDecorations();
-                const config = vscode.workspace.getConfiguration('localComments');
-                const autoSave = config.get<boolean>('autoSave', true);
-                if (autoSave) {
-                    saveComments();
-                }
-                
-                refreshSidebar();
+    const config = vscode.workspace.getConfiguration('localComments');
+    const confirmDelete = config.get<boolean>('confirmDelete', true);
+
+    if (confirmDelete) {
+        const result = await vscode.window.showWarningMessage(
+            'Are you sure you want to delete this comment?',
+            'Delete', 'Cancel'
+        );
+        if (result !== 'Delete') {
+            return;
+        }
+    }
+
+    const fileComments = commentData[fileName];
+    if (fileComments) {
+        const index = fileComments.findIndex(c => c.id === commentId);
+        if (index !== -1) {
+            fileComments.splice(index, 1);
+            if (fileComments.length === 0) {
+                delete commentData[fileName];
             }
+
+            updateDecorations();
+            const autoSave = config.get<boolean>('autoSave', true);
+            if (autoSave) {
+                saveComments();
+            }
+
+            refreshSidebar();
         }
     }
 }


### PR DESCRIPTION
Hi there! Nice extension, hope you're open for contributions 😀

This was just a little UX tweak to (optionally) reduce friction when deleting comments.

## Summary

- Add new localComments.confirmDelete configuration option to bypass the confirmation dialog when deleting comments
- Default behavior unchanged (confirmation enabled)
- When disabled, comments are deleted immediately for smoother UX

## Changes

- package.json: Added localComments.confirmDelete boolean setting (default: true)
- src/extension.ts: Made confirmation dialog conditional based on setting
- CHANGELOG.md: Documented feature under Unreleased

## Test Plan

- Build passes (yarn compile)
- Lint passes (yarn lint)
- Manual testing: confirmDelete: true shows dialog before deletion
- Manual testing: confirmDelete: false deletes immediately
- Setting change takes effect without extension restart